### PR TITLE
Add dependency to zlib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ homepage = "https://github.com/PistonDevelopers/freetype-rs"
 
 [build-dependencies]
 pkg-config = "*"
+
+[dependencies]
+libz-sys = "*"


### PR DESCRIPTION
This is required by the cargo build system.
