### PR TITLE
Use the new syntax in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,9 +5,9 @@ fn main() {
         Ok(_) => return,
         Err(_) => {
             if cfg!(windows) {
-                println!("cargo:rustc-flags=-l freetype-6:dylib");
+                println!("cargo:rustc-link-lib=dylib=freetype-6");
             } else {
-                println!("cargo:rustc-flags=-l freetype:dylib");
+                println!("cargo:rustc-link-lib=dylib=freetype");
             }
         }
     }


### PR DESCRIPTION
Someone reported on IRC that it no longer works. I didn't test the new syntax (we'll see what travis says), but it matches what the docs say: http://doc.crates.io/build-script.html#outputs-of-the-build-script