### PR TITLE
Remove "-6" suffix

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,11 +4,7 @@ fn main() {
     match pkg_config::find_library("freetype2") {
         Ok(_) => return,
         Err(_) => {
-            if cfg!(windows) {
-                println!("cargo:rustc-link-lib=dylib=freetype-6");
-            } else {
-                println!("cargo:rustc-link-lib=dylib=freetype");
-            }
+            println!("cargo:rustc-link-lib=dylib=freetype");
         }
     }
 }


### PR DESCRIPTION
Neither MSYS2 nor [the windows builds](https://github.com/PistonDevelopers/binaries/tree/master/x86_64) use this suffix.