### PR TITLE
Add FT_Get_Sfnt_Table support for the BSDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "freetype-sys"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Coeuvre <coeuvre@gmail.com>"]
 links = "freetype"
 build = "build.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -882,7 +882,6 @@ pub fn FT_HAS_COLOR(face: FT_Face) -> bool {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
 extern {
     pub fn FT_Get_Sfnt_Table(face: FT_Face, tag: FT_Sfnt_Tag) -> *mut c_void;
 }


### PR DESCRIPTION
I'm trying to use https://github.com/jwilm/alacritty on OpenBSD and the latest version of alacritty needs `FT_Get_Sfnt_Table` (via freetype-rs `TrueTypeOS2Table::from_face`).

Free/Net/OpenBSD support FT_Get_Sfnt_Table in their Freetype2 libraries as explained in the commit message. I've added the corresponding conditional compilation attribute in `src/lib.rs`.

I've tested this on OpenBSD and alacritty compiles and works as expected with this change.

It would be good if we can do a patch level version bump for freetype-sys (like 0.7.1) so we can update the entire dependency chain. I can add a second commit to this PR changing `Cargo.toml` if it's ok.

P.S. I'll open a separate PR for freetype-rs.