### PR TITLE
Allow opting out of Freetype system library linkage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,14 @@ readme = "README.md"
 repository = "https://github.com/PistonDevelopers/freetype-sys.git"
 homepage = "https://github.com/PistonDevelopers/freetype-sys"
 
+[features]
+default = ["link-freetype"]
+
+# Automatically try to link in the Freetype library.
+link-freetype = ["pkg-config"]
+
 [build-dependencies]
-pkg-config = "0.3.11"
+pkg-config = { version = "0.3.11", optional = true }
 
 [dependencies]
 libz-sys = "1.0.18"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "link-freetype")]
 extern crate pkg_config;
 
 fn main() {
+    #[cfg(feature = "link-freetype")]
     match pkg_config::find_library("freetype2") {
         Ok(_) => return,
         Err(_) => {


### PR DESCRIPTION
In our project, we compile Freetype into the Rust binary ourselves and
don't want to link to the system library. This adds the `link-freetype`
option (enabled by default) to ensure that the system library is never
used.