### PR TITLE
Export C include path information into Cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 freetype-sys [![Build Status](https://travis-ci.org/PistonDevelopers/freetype-sys.svg?branch=master)](https://travis-ci.org/PistonDevelopers/freetype-sys) [![Build status](https://ci.appveyor.com/api/projects/status/cx6i2r1ibroywo2q?svg=true)](https://ci.appveyor.com/project/jhasse/freetype-sys)
 ============
 
-Low level bindings for the FreeType font library
+Low level bindings for the FreeType font library.
+
+## C headers
+
+If your Rust project includes C code that needs to interface with FreeType, the
+environment variable `DEP_FREETYPE_INCLUDE` will be exported to its build
+script, giving the path in which the FreeType include files may be found. This
+path may be in the system or it may be inside this crate’s `$OUT_DIR`, depending
+on whether it was necessary to build the FreeType library locally or not.
 
 ## For windows users
 

--- a/build.rs
+++ b/build.rs
@@ -6,10 +6,17 @@ use std::env;
 
 fn main() {
     let target = env::var("TARGET").unwrap();
-    if !target.contains("android")
-        && pkg_config::Config::new().atleast_version("18.5.12").find("freetype2").is_ok()
-    {
-        return
+
+    if !target.contains("android") {
+        if let Ok(dep) = pkg_config::Config::new()
+            .atleast_version("18.5.12")
+            .find("freetype2")
+        {
+            for inc in &dep.include_paths[..] {
+                println!("cargo:include={}", inc.to_str().unwrap());
+            }
+            return;
+        }
     }
 
     let mut config = Config::new("freetype2");
@@ -27,4 +34,5 @@ fn main() {
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
     println!("cargo:rustc-link-lib=static=freetype");
     println!("cargo:outdir={}", out_dir);
+    println!("cargo:include={}/include", out_dir);
 }


### PR DESCRIPTION
This changes the build script to print a magic string that depending crates can use to find the path to the FreeType C includes. That way, if those crates have their own C code that needs to interface with FreeType, there will be an easy and reliable way to do so.

(Yes, [I have a crate that needs this](https://github.com/tectonic-typesetting/tectonic.git).)