### PR TITLE
Restore pkg-config / dynamic linking support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ homepage = "https://github.com/PistonDevelopers/freetype-sys"
 
 [build-dependencies]
 cc = "1"
+pkg-config = "0.3.11"
 
 [dependencies]
 libc = "0.2.42"

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 fn add_sources(build: &mut cc::Build, root: &str, files: &[&str]) {
     let root = std::path::Path::new(root);
     build.files(files.iter().map(|src| {
@@ -10,6 +12,16 @@ fn add_sources(build: &mut cc::Build, root: &str, files: &[&str]) {
 }
 
 fn main() {
+    let target = env::var("TARGET").unwrap();
+    if !target.contains("android")
+        && pkg_config::Config::new()
+            .atleast_version("24.3.18")
+            .find("freetype2")
+            .is_ok()
+    {
+        return;
+    }
+
     let mut build = cc::Build::new();
 
     build


### PR DESCRIPTION
This is a partial revert of PR https://github.com/PistonDevelopers/freetype-sys/pull/106 which seems to have accidentally dropped support for using pkg-config / dynamically linking with system libfreetype.

Compared to the pkg-config related code that was removed, the only change I made is updating the minimum required version to "24.3.18" in the pkg-config call - which corresponds to freetype2 v2.12.1 (which is what the bundled version was updated to with the last release).

Fixes #108 