### PR TITLE
Skip pkgconfig on OpenHarmony OS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,7 @@ fn add_sources(build: &mut cc::Build, root: &str, files: &[&str]) {
 fn main() {
     let target = env::var("TARGET").unwrap();
     if !target.contains("android")
+        && !target.contains("ohos")
         && pkg_config::Config::new()
             .atleast_version("24.3.18")
             .find("freetype2")


### PR DESCRIPTION
pkgconfig `find()` and `probe()` functions will return `Ok()` when building for `-ohos` targets, however there is no prebuilt dynamic or static library to link to in the SDK or on OHOS devices. It's required to build freetype from source instead.