### PR TITLE
Add a `bundled` Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "freetype-sys"
-version = "0.20.1"
+version = "0.21.0"
 authors = ["Coeuvre <coeuvre@gmail.com>"]
 links = "freetype"
 build = "build.rs"
@@ -12,6 +12,9 @@ readme = "README.md"
 repository = "https://github.com/PistonDevelopers/freetype-sys.git"
 homepage = "https://github.com/PistonDevelopers/freetype-sys"
 edition = "2018"
+
+[features]
+bundled = []
 
 [build-dependencies]
 cc = "1"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ freetype-sys [![Build Status](https://travis-ci.org/PistonDevelopers/freetype-sy
 
 Low level bindings for the FreeType font library.
 
+# Statically linking against FreeType
+
+If the `bundled` feature is enabled, `freetype-sys` will build and link a static copy of FreeType. This requires a C compiler. The included version of FreeType is 2.13.2.
+
+```
+[dependencies]
+freetype-sys = { version = "0.21", features = ["bundled"] }
+```
+
 ## For Windows users
 
 ### -pc-windows-gnu

--- a/build.rs
+++ b/build.rs
@@ -12,14 +12,15 @@ fn add_sources(build: &mut cc::Build, root: &str, files: &[&str]) {
 }
 
 fn main() {
-    let target = env::var("TARGET").unwrap();
-    if !target.contains("android")
-        && !target.contains("ohos")
-        && pkg_config::Config::new()
-            .atleast_version("24.3.18")
-            .find("freetype2")
-            .is_ok()
-    {
+    if !cfg!(feature = "bundled") {
+        let target = env::var("TARGET").unwrap();
+        if !target.contains("android")
+            && !target.contains("ohos") {
+            pkg_config::Config::new()
+                .atleast_version("24.3.18")
+                .probe("freetype2")
+                .unwrap();
+        }
         return;
     }
 


### PR DESCRIPTION
Previously, `freetype-sys` would first try to find the system FreeType
via pkg-config and then fall back to compiling the vendored version of
FreeType unconditionally.

This change adds a `bundled` feature which allows the users of the crate
to have more control over whether or not the static version of FreeType
is used. If the feature is not passed, FreeType will not be
statically-linked even if it isn't found via pkg-config. This matches
the approach that `harfbuzz-sys` uses as well as `openssl-sys` (via the
`vendored` feature).
