### PR TITLE
Silence ptr comparison warning to fix CI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+// This warning should probably be addressed, but that would be a breaking change.
+// For now we simply silence the warning, to get CI running again.
+#![allow(unpredictable_function_pointer_comparisons)]
 #![deny(missing_copy_implementations)]
 
 use core::ffi::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_ushort, c_void};


### PR DESCRIPTION

The warning appears in multiple places, and would probably need some thought. 
For C freetype functions it should be fine anyway.

```
warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
   --> src/lib.rs:896:5
    |
890 | #[derive(Debug, Hash, PartialEq, Eq)]
    |                       --------- in this derive macro expansion
...
896 |     pub gray_spans: FT_SpanFunc,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the address of the same function can vary between different codegen units
    = note: furthermore, different functions could have the same address after being merged together
    = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
```