### PR TITLE
 libz: Use include path from libz-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ homepage = "https://github.com/PistonDevelopers/freetype-sys"
 edition = "2018"
 
 [features]
-bundled = []
+bundled = ["libz-sys"]
 
 [dependencies]
-libz-sys = "1.1.20"
+libz-sys = {  version = "1.1.20", optional = true }
 
 [build-dependencies]
 cc = "1"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::env::VarError;
 
 fn add_sources(build: &mut cc::Build, root: &str, files: &[&str]) {
     let root = std::path::Path::new(root);
@@ -92,10 +93,22 @@ fn main() {
 
     build.compile("freetype2");
 
-    println!("cargo:rustc-link-lib=z");
+    // libz-sys comma separates multiple include paths.
+    let zlib_include_paths = match env::var("DEP_Z_INCLUDE") {
+        Ok(include_paths) => include_paths.split(",").map(String::from).collect(),
+        Err(VarError::NotPresent) => {
+            // For some targets (e.g. android and -ohos), libz-sys does not emit the variable,
+            // but we expect the header to be in the sysroot instead so it's fine.
+            vec![]
+        }
+        Err(VarError::NotUnicode(_os_str_paths)) => {
+            println!("cargo:warning:libz-sys header files at non-unicode path. Ignoring");
+            vec![]
+        }
+    };
 
     let mut build = cc::Build::new();
-    build.include("libpng").include("libz-sys/src/zlib");
+    build.include("libpng").includes(zlib_include_paths);
     build
         .file("libpng/png.c")
         .file("libpng/pngerror.c")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@
 
 use core::ffi::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_ushort, c_void};
 
+#[cfg(feature = "bundled")]
+extern crate libz_sys;
+
 mod tt_tables;
 pub use crate::tt_tables::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+// This warning should probably be addressed, but that would be a breaking change.
+// For now we simply silence the warning, to get CI running again.
+#![allow(unpredictable_function_pointer_comparisons)]
 #![deny(missing_copy_implementations)]
 
 use core::ffi::{c_char, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_ushort, c_void};


### PR DESCRIPTION
Follow-up to #152.

The vendored libz-sys folder was never included in the
cargo package, so the previous include can't have worked.
It probably wasn't a problem in practice, since libz include
headers are usually installed.
Nevertheless this should be fixed, and the usual way is using the
`DEP_` syntax to read the `include` variable printed from the build-script
of libz-sys, which gives us the header file locations.

Fixes: #149

